### PR TITLE
Added additional mode for creator/contributor slurp

### DIFF
--- a/islandora_transforms/ocls_MODS_slurp.xslt
+++ b/islandora_transforms/ocls_MODS_slurp.xslt
@@ -51,7 +51,7 @@
   <!-- Name -->
   <xsl:template match="mods:mods/mods:name[@type = 'personal' or @type = 'corporate' or @type = 'conference']" mode="ocls_mods_slurp">
     <xsl:variable name="uppercase" select="'ABCDEFGHIJKLMNOPQRSTUVWXYZ- '" />
-    <xsl:variable name="lowercase" select="'abcdefghijklmnopqrstuvwxyz'" />
+    <xsl:variable name="lowercase" select="'abcdefghijklmnopqrstuvwxyz__'" />
     <xsl:variable name="name_type" select="@type" />
     <xsl:variable name="role_term" select="translate(mods:role/mods:roleTerm/text(), $uppercase, $lowercase)" />
     <xsl:variable name="name">
@@ -78,7 +78,7 @@
   </xsl:template>
 
   <!-- Creator & Contributors -->
-  <xsl:template match="mods:mods/mods:name[@type = 'personal'][mods:role/mods:roleTerm[. = 'Creator' or . = 'Contributor']]" mode="ocls_mods_slurp">
+  <xsl:template match="mods:mods/mods:name[@type = 'personal'][mods:role/mods:roleTerm[. = 'Creator' or . = 'Contributor']]" mode="ocls_mods_creator_contributor_slurp">
     <xsl:variable name="name_type" select="@type" />
     <xsl:variable name="name">
       <xsl:for-each select="mods:namePart[not(@type)]">

--- a/islandora_transforms/slurp_all_MODS_to_solr.xslt
+++ b/islandora_transforms/slurp_all_MODS_to_solr.xslt
@@ -29,6 +29,7 @@
     </xsl:apply-templates>
 
     <xsl:apply-templates mode="ocls_mods_slurp" select="$content//mods:mods[1]"/>
+    <xsl:apply-templates mode="ocls_mods_creator_contributor_slurp" select="$content//mods:mods[1]/mods:name"/>
   </xsl:template>
 
   <!-- Handle dates. -->


### PR DESCRIPTION
Better translating for dynamic field name generation, added additional template mode so that we can independently index all `mods:name` information into the catch all `creators_contributors` field.